### PR TITLE
Fix issue #10 - exitcode not reporting correctly

### DIFF
--- a/src/Ssh2Channel.cpp
+++ b/src/Ssh2Channel.cpp
@@ -200,7 +200,7 @@ std::error_code Ssh2Channel::closeChannelSession()
     std::error_code error_code = ssh2_success;
     libssh2_channel_flush_ex(ssh2_channel_, 0);
     libssh2_channel_flush_ex(ssh2_channel_, 1);
-    const int ssh2_method_result = libssh2_channel_send_eof(ssh2_channel_);
+    const int ssh2_method_result = libssh2_channel_close(ssh2_channel_);
     switch (ssh2_method_result) {
     case LIBSSH2_ERROR_EAGAIN:
         setSsh2ChannelState(ChannelStates::Closing);


### PR DESCRIPTION
Switched from channel_send_eof() to channel_close() fixes the exitcode issue